### PR TITLE
Bump plugins and move to Java 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
     <!-- Dependencies -->
     <android.version>4.1.1.4</android.version>
-    <android.platform>16</android.platform>
+    <android.platform>19</android.platform>
     <android.support.version>r7</android.support.version>
 
     <!-- Sample Dependencies -->
@@ -128,15 +128,15 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>2.5</version>
           <configuration>
-            <source>1.6</source>
-            <target>1.6</target>
+            <source>1.7</source>
+            <target>1.7</target>
           </configuration>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>2.9.1</version>
+          <version>2.12</version>
           <configuration>
             <failsOnError>true</failsOnError>
             <configLocation>../checkstyle.xml</configLocation>
@@ -185,7 +185,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>2.5</version>
         <configuration>
           <autoVersionSubmodules>true</autoVersionSubmodules>
         </configuration>


### PR DESCRIPTION
Not sure if we want to move public projects to Java 7. If so, here's a start, otherwise close this.

[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Flow (Parent) ..................................... SUCCESS [0.357s]
[INFO] Flow .............................................. SUCCESS [5.302s]
[INFO] Flow Sample ....................................... SUCCESS [8.967s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 15.551s
[INFO] Finished at: Wed Apr 02 19:31:16 PDT 2014
[INFO] Final Memory: 52M/451M
[INFO] ------------------------------------------------------------------------
