### PR TITLE
Fixed Utils waitForMeasureLoop

### DIFF
--- a/flow-sample/src/main/java/com/example/flow/Utils.java
+++ b/flow-sample/src/main/java/com/example/flow/Utils.java
@@ -34,9 +34,9 @@ public final class Utils {
       return;
     }
 
-    final ViewTreeObserver observer = view.getViewTreeObserver();
-    observer.addOnPreDrawListener(new ViewTreeObserver.OnPreDrawListener() {
+    view.getViewTreeObserver().addOnPreDrawListener(new ViewTreeObserver.OnPreDrawListener() {
       @Override public boolean onPreDraw() {
+        final ViewTreeObserver observer = view.getViewTreeObserver();
         if (observer.isAlive()) {
           observer.removeOnPreDrawListener(this);
         }


### PR DESCRIPTION
Sometimes the observer is lost between adding and calling the inner method. You need to re request the observer inside the block to get the alive one.
Edge case but much safer.
