### PR TITLE
Make flow.replace(Backstack) public

### DIFF
--- a/flow/src/main/java/flow/Flow.java
+++ b/flow/src/main/java/flow/Flow.java
@@ -129,7 +129,7 @@ public final class Flow {
   }
 
   /** Replaces to a new backstack. */
-  private void replace(Backstack newBackstack) {
+  public void replace(Backstack newBackstack) {
     listener.go(newBackstack, Direction.REPLACE);
     backstack = newBackstack;
   }


### PR DESCRIPTION
Replace method in flow is private, while forward and backward methods are public.
In cases to replace backstack (e.g. delete entry from middle), replace method should be public too.
