### PR TITLE
PathContainerView extends Flow.Dispatcher.

### DIFF
--- a/flow-sample/src/main/java/com/example/flow/MainActivity.java
+++ b/flow-sample/src/main/java/com/example/flow/MainActivity.java
@@ -125,7 +125,7 @@ public class MainActivity extends Activity implements Flow.Dispatcher {
 
   @Override public void dispatch(Traversal traversal, TraversalCallback callback) {
     Path path = traversal.destination.current();
-    container.executeTraversal(traversal, callback);
+    container.dispatch(traversal, callback);
 
     setTitle(path.getClass().getSimpleName());
 

--- a/flow-sample/src/main/java/com/example/flow/pathview/FramePathContainerView.java
+++ b/flow-sample/src/main/java/com/example/flow/pathview/FramePathContainerView.java
@@ -61,10 +61,9 @@ public class FramePathContainerView extends FrameLayout
     super.onFinishInflate();
   }
 
-  @Override public void executeTraversal(Flow.Traversal traversal,
-      final Flow.TraversalCallback callback) {
+  @Override public void dispatch(Flow.Traversal traversal, final Flow.TraversalCallback callback) {
     disabled = true;
-    container.executeTraversal(traversal, new Flow.TraversalCallback() {
+    container.executeTraversal(this, traversal, new Flow.TraversalCallback() {
       @Override public void onTraversalCompleted() {
         callback.onTraversalCompleted();
         disabled = false;

--- a/flow-sample/src/main/java/com/example/flow/pathview/MasterPathContainerView.java
+++ b/flow-sample/src/main/java/com/example/flow/pathview/MasterPathContainerView.java
@@ -22,8 +22,7 @@ public class MasterPathContainerView extends FramePathContainerView {
         });
   }
 
-  @Override public void executeTraversal(Flow.Traversal traversal,
-      final Flow.TraversalCallback callback) {
+  @Override public void dispatch(Flow.Traversal traversal, final Flow.TraversalCallback callback) {
 
     MasterDetailPath currentMaster =
         ((MasterDetailPath) Flow.get(getContext()).getBackstack().current()).getMaster();
@@ -34,7 +33,7 @@ public class MasterPathContainerView extends FramePathContainerView {
     if (getCurrentChild() != null && newMaster.equals(currentMaster)) {
       callback.onTraversalCompleted();
     } else {
-      super.executeTraversal(traversal, new Flow.TraversalCallback() {
+      super.dispatch(traversal, new Flow.TraversalCallback() {
         @Override public void onTraversalCompleted() {
           callback.onTraversalCompleted();
         }

--- a/flow-sample/src/main/java/com/example/flow/view/TabletMasterDetailRoot.java
+++ b/flow-sample/src/main/java/com/example/flow/view/TabletMasterDetailRoot.java
@@ -52,8 +52,7 @@ public class TabletMasterDetailRoot extends LinearLayout
     return this;
   }
 
-  @Override public void executeTraversal(Flow.Traversal traversal,
-      Flow.TraversalCallback callback) {
+  @Override public void dispatch(Flow.Traversal traversal, Flow.TraversalCallback callback) {
 
     class CountdownCallback implements Flow.TraversalCallback {
       final Flow.TraversalCallback wrapped;
@@ -75,8 +74,8 @@ public class TabletMasterDetailRoot extends LinearLayout
 
     disabled = true;
     callback = new CountdownCallback(callback);
-    detailContainer.executeTraversal(traversal, callback);
-    masterContainer.executeTraversal(traversal, callback);
+    detailContainer.dispatch(traversal, callback);
+    masterContainer.dispatch(traversal, callback);
   }
 
   @Override public boolean onUpPressed() {

--- a/flow/src/main/java/flow/PathContainer.java
+++ b/flow/src/main/java/flow/PathContainer.java
@@ -69,15 +69,13 @@ public abstract class PathContainer {
 
   private static final Map<Class, Integer> PATH_LAYOUT_CACHE = new LinkedHashMap<>();
 
-  private final PathContainerView view;
   private final int tagKey;
 
   protected PathContainer(PathContainerView view, int tagKey) {
-    this.view = view;
     this.tagKey = tagKey;
   }
 
-  public final void executeTraversal(Flow.Traversal traversal,
+  public final void executeTraversal(PathContainerView view, Flow.Traversal traversal,
       final Flow.TraversalCallback callback) {
     final View oldChild = view.getCurrentChild();
     Backstack.Entry entry = traversal.destination.currentEntry();

--- a/flow/src/main/java/flow/PathContainerView.java
+++ b/flow/src/main/java/flow/PathContainerView.java
@@ -19,12 +19,12 @@ package flow;
 import android.content.Context;
 import android.view.ViewGroup;
 
-public interface PathContainerView {
+public interface PathContainerView extends Flow.Dispatcher {
   ViewGroup getCurrentChild();
 
   ViewGroup getContainerView();
 
   Context getContext();
 
-  void executeTraversal(Flow.Traversal traversal, Flow.TraversalCallback callback);
+  void dispatch(Flow.Traversal traversal, Flow.TraversalCallback callback);
 }


### PR DESCRIPTION
And PathContainer doesn't need to keep its client view in a field.

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Flow (Parent) ...................................... SUCCESS [  0.455 s]
[INFO] Flow ............................................... SUCCESS [  3.813 s]
[INFO] Flow Sample ........................................ SUCCESS [  9.644 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 15.112 s
[INFO] Finished at: 2014-11-11T09:09:57-08:00
[INFO] Final Memory: 68M/720M
[INFO] ------------------------------------------------------------------------
```
