### PR TITLE
Update flow#resetTo() javadoc

### DIFF
--- a/flow/src/main/java/flow/Flow.java
+++ b/flow/src/main/java/flow/Flow.java
@@ -146,8 +146,8 @@ public final class Flow {
   }
 
   /**
-   * Reset to the specified screen. Pops until the screen is found. If the screen is not found,
-   * the entire backstack is replaced with the screen.
+   * Set the specified screen to the top of the backstack. If the screen already
+   * exists in the backstack, the screen will be moved to the top of the backstack.
    */
   public void resetTo(final Path path) {
     move(new PendingTraversal() {


### PR DESCRIPTION
The javadoc comment for `flow#resetTo()` is outdated. This is noted in issue #21.  Updated the javadoc
to reflect the methods current implementation.

