### PR TITLE
Fix mortar sample ClassCastException

### DIFF
--- a/flow-sample/src/main/java/com/example/flow/pathview/SimplePathContainer.java
+++ b/flow-sample/src/main/java/com/example/flow/pathview/SimplePathContainer.java
@@ -58,10 +58,10 @@ public class SimplePathContainer extends PathContainer {
 
     Path to = traversalState.toPath();
 
-    ViewGroup newView;
+    View newView;
     context = PathContext.create(oldPath, to, contextFactory);
     int layout = getLayout(to);
-    newView = (ViewGroup) LayoutInflater.from(context)
+    newView = LayoutInflater.from(context)
         .cloneInContext(context)
         .inflate(layout, containerView, false);
 


### PR DESCRIPTION
The `newView` in flow-sample need not be a `ViewGroup`.  It actually causes the mortar sample to throw a ClassCastException like the following:

```
        AndroidRuntime  E  FATAL EXCEPTION: main
                        E  Process: com.example.mortar, PID: 2354
                        E  java.lang.ClassCastException: com.example.mortar.view.FriendView cannot be cast to android.view.ViewGroup
                        E      at com.example.flow.pathview.SimplePathContainer.performTraversal(SimplePathContainer.java:64)
                        E      at flow.PathContainer.executeTraversal(PathContainer.java:87)
                        E      at com.example.flow.pathview.FramePathContainerView.dispatch(FramePathContainerView.java:64)
                        E      at com.example.mortar.MortarDemoActivity.dispatch(MortarDemoActivity.java:85)
                        E      at flow.Flow$PendingTraversal.go(Flow.java:356)
                        E      at flow.Flow$2.doExecute(Flow.java:143)
                        E      at flow.Flow$PendingTraversal.execute(Flow.java:364)
                        E      at flow.Flow.move(Flow.java:273)
                        E      at flow.Flow.goTo(Flow.java:140)
                        E      at com.example.mortar.screen.FriendListScreen$Presenter.onFriendSelected(FriendListScreen.java:60)
                        E      at com.example.mortar.view.FriendListView$1.onItemClick(FriendListView.java:55)
                        E      at android.widget.AdapterView.performItemClick(AdapterView.java:299)
                        E      at android.widget.AbsListView.performItemClick(AbsListView.java:1113)
                        E      at android.widget.AbsListView$PerformClick.run(AbsListView.java:2911)
                        E      at android.widget.AbsListView$3.run(AbsListView.java:3645)
                        E      at android.os.Handler.handleCallback(Handler.java:733)
                        E      at android.os.Handler.dispatchMessage(Handler.java:95)
                        E      at android.os.Looper.loop(Looper.java:136)
                        E      at android.app.ActivityThread.main(ActivityThread.java:5001)
                        E      at java.lang.reflect.Method.invokeNative(Native Method)
                        E      at java.lang.reflect.Method.invoke(Method.java:515)
                        E      at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:785)
                        E      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:601)
                        E      at dalvik.system.NativeStart.main(Native Method)
```