### PR TITLE
Fix NPE in getSystemService() override

### DIFF
--- a/flow-sample/src/main/java/com/example/flow/MainActivity.java
+++ b/flow-sample/src/main/java/com/example/flow/MainActivity.java
@@ -91,10 +91,11 @@ public class MainActivity extends Activity implements Flow.Dispatcher {
     super.onPause();
   }
 
-
-
   @Override public Object getSystemService(String name) {
-    Object service = flowSupport.getSystemService(name);
+    Object service = null;
+    if (flowSupport != null) {
+       service = flowSupport.getSystemService(name);
+    }
     return service != null ? service : super.getSystemService(name);
   }
 


### PR DESCRIPTION
I just downloaded the sample and for some reason getSystemService("layout_inflater") was being called before onCreate() so the app was crashing (on Nexus 6 and Genymotion 4.4)