### PR TITLE
New World API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,17 @@
 # Flow
 
-Flow is a small library that helps with describing an app as a collection of moderately independent screens. These screens can be pushed onto a concrete backstack to provide navigation history.
+Flow allows you to enumerate to your app's UI states and navigate between them.
 
-## Screen
+## Path
 
-A screen describes a distinct state of an application. It contains enough information to bootstrap the view.
+A Path object maps to a distinct UI state of your app. It contains just enough information to
+recreate that state.
 
 ```java
 @Layout(R.layout.track)
-public class TrackScreen implements HasParent<AlbumScreen> {
+public class TrackScreen extends Path {
   public final int albumId;
   public final int trackId;
-
-  @Override public AlbumScreen getParent() {
-    return new AlbumScreen(albumId);
-  }
 
   public TrackScreen(int albumId, int trackId) {
     this.albumId = albumId;
@@ -23,20 +20,32 @@ public class TrackScreen implements HasParent<AlbumScreen> {
 }
 ```
 
-The `HasParent` interface is used to support the *up* notion used in Android.
-
 ## Backstack
 
-The backstack is the history of screens, with the head being the current or last-most screen.
+The Backstack is the history of Paths, with the head being the current Path.
 
 ## Flow
 
-The flow holds the current truth about your application, the history of screens. It can be told to transition to another screen by simply instantiating the screen you want to go to.
+The Flow holds the current Backstack and offers navigation.
 
 ```java
-flow.goTo(new TrackScreen(albumId, trackId));
+flow.set(new TrackScreen(albumId, trackId));
+
+flow.goBack();
 ```
 
+## Dispatcher
+Your app provides Flow with a Dispatcher which executes UI state changes.
+
+```java
+flow.setDispatcher(new Flow.Dispatcher() {
+ @Override public void dispatch(Traversal traversal, TraversalCallback callback) {
+      Path newPath = traversal.destination.current();
+      displayViewFor(newPath);
+      callback.onTraversalCompleted();
+    }
+});
+```
 
 
 Download

--- a/flow-sample/src/main/java/com/example/flow/MainActivity.java
+++ b/flow-sample/src/main/java/com/example/flow/MainActivity.java
@@ -109,7 +109,7 @@ public class MainActivity extends Activity implements Flow.Dispatcher {
         .setShowAsActionFlags(SHOW_AS_ACTION_ALWAYS)
         .setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
           @Override public boolean onMenuItemClick(MenuItem menuItem) {
-            Flow.get(MainActivity.this).goTo(new Paths.FriendList());
+            Flow.get(MainActivity.this).set(new Paths.FriendList());
             return true;
           }
         });

--- a/flow-sample/src/main/java/com/example/flow/view/ConversationListView.java
+++ b/flow-sample/src/main/java/com/example/flow/view/ConversationListView.java
@@ -41,7 +41,7 @@ public class ConversationListView extends ListView implements IsMasterView {
     setAdapter(adapter);
     setOnItemClickListener(new OnItemClickListener() {
       @Override public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-        Flow.get(getContext()).goTo(new Paths.Conversation(position));
+        Flow.get(getContext()).set(new Paths.Conversation(position));
       }
     });
   }

--- a/flow-sample/src/main/java/com/example/flow/view/ConversationView.java
+++ b/flow-sample/src/main/java/com/example/flow/view/ConversationView.java
@@ -48,7 +48,7 @@ public class ConversationView extends ListView {
     setOnItemClickListener(new OnItemClickListener() {
       @Override public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
         int messageIndex = conversationList.indexOf(conversation);
-        Flow.get(getContext()).goTo(new Paths.Message(messageIndex, position));
+        Flow.get(getContext()).set(new Paths.Message(messageIndex, position));
       }
     });
   }

--- a/flow-sample/src/main/java/com/example/flow/view/FriendListView.java
+++ b/flow-sample/src/main/java/com/example/flow/view/FriendListView.java
@@ -47,7 +47,7 @@ public class FriendListView extends ListView implements IsMasterView {
     setAdapter(adapter);
     setOnItemClickListener(new OnItemClickListener() {
       @Override public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-        Flow.get(getContext()).goTo(new Paths.Friend(position));
+        Flow.get(getContext()).set(new Paths.Friend(position));
       }
     });
   }

--- a/flow-sample/src/main/java/com/example/flow/view/MessageView.java
+++ b/flow-sample/src/main/java/com/example/flow/view/MessageView.java
@@ -63,7 +63,7 @@ public class MessageView extends LinearLayout {
   @OnClick(R.id.user) void userClicked() {
     int position = friendList.indexOf(message.from);
     if (position != -1) {
-      Flow.get(getContext()).goTo(new Paths.Friend(position));
+      Flow.get(getContext()).set(new Paths.Friend(position));
     }
   }
 }

--- a/flow/src/test/java/flow/FlowTest.java
+++ b/flow/src/test/java/flow/FlowTest.java
@@ -28,12 +28,14 @@ public class FlowTest {
   static class Uno extends Path {
   }
 
+  @SuppressWarnings("deprecation")
   static class Dos extends Path implements HasParent {
     @Override public Uno getParent() {
       return new Uno();
     }
   }
 
+  @SuppressWarnings("deprecation")
   static class Tres extends Path implements HasParent {
     @Override public Dos getParent() {
       return new Dos();
@@ -61,11 +63,11 @@ public class FlowTest {
     Flow flow = new Flow(backstack);
     flow.setDispatcher(new FlowDispatcher());
 
-    flow.goTo(new Dos());
+    flow.set(new Dos());
     assertThat(lastStack.current()).isInstanceOf(Dos.class);
     assertThat(lastDirection).isSameAs(Flow.Direction.FORWARD);
 
-    flow.goTo(new Tres());
+    flow.set(new Tres());
     assertThat(lastStack.current()).isInstanceOf(Tres.class);
     assertThat(lastDirection).isSameAs(Flow.Direction.FORWARD);
 
@@ -112,7 +114,7 @@ public class FlowTest {
     }
 
     Ourrobouros listener = new Ourrobouros();
-    listener.flow.goTo(new Dos());
+    listener.flow.set(new Dos());
   }
 
   @Test public void noUpNoUps() {
@@ -122,11 +124,13 @@ public class FlowTest {
     lastStack = null;
     lastDirection = null;
 
+    //noinspection deprecation
     assertThat(flow.goUp()).isFalse();
     assertThat(lastStack).isNull();
     assertThat(lastDirection).isNull();
   }
 
+  @SuppressWarnings("deprecation")
   @Test public void upAndDown() {
     Backstack backstack = Backstack.single(new Tres());
     Flow flow = new Flow(backstack);
@@ -162,7 +166,7 @@ public class FlowTest {
     assertThat(flow.goBack()).isFalse();
   }
 
-  @Test public void replaceBuildsBackStackFromUpLinks() {
+  @SuppressWarnings("deprecation") @Test public void replaceBuildsBackStackFromUpLinks() {
     Backstack backstack =
         Backstack.emptyBuilder().addAll(Arrays.<Path>asList(able, baker, charlie, delta)).build();
     Flow flow = new Flow(backstack);
@@ -183,7 +187,24 @@ public class FlowTest {
     assertThat(flow.goBack()).isFalse();
   }
 
-  @Test public void resetGoesBack() {
+  @Test public void setBackstackWorks() {
+    Backstack backstack =
+        Backstack.emptyBuilder().addAll(Arrays.<Path>asList(able, baker)).build();
+    Flow flow = new Flow(backstack);
+    FlowDispatcher dispatcher = new FlowDispatcher();
+    flow.setDispatcher(dispatcher);
+
+    Backstack newBackstack = Backstack.emptyBuilder().addAll(
+        Arrays.<Path>asList(charlie, delta)).build();
+    flow.set(newBackstack, Flow.Direction.FORWARD);
+    assertThat(lastDirection).isSameAs(Flow.Direction.FORWARD);
+    assertThat(lastStack.current()).isSameAs(delta);
+    assertThat(flow.goBack()).isTrue();
+    assertThat(lastStack.current()).isSameAs(charlie);
+    assertThat(flow.goBack()).isFalse();
+  }
+
+  @Test public void setPathGoesBack() {
     Backstack backstack =
         Backstack.emptyBuilder().addAll(Arrays.<Path>asList(able, baker, charlie, delta)).build();
     Flow flow = new Flow(backstack);
@@ -191,7 +212,7 @@ public class FlowTest {
 
     assertThat(backstack.size()).isEqualTo(4);
 
-    flow.resetTo(charlie);
+    flow.set(charlie);
     assertThat(lastStack.current()).isEqualTo(charlie);
     assertThat(lastStack.size()).isEqualTo(3);
     assertThat(lastDirection).isEqualTo(Flow.Direction.BACKWARD);
@@ -207,14 +228,14 @@ public class FlowTest {
     assertThat(flow.goBack()).isFalse();
   }
 
-  @Test public void resetToMissingScreenPushes() {
+  @Test public void setPathToMissingPathPushes() {
     Backstack backstack =
         Backstack.emptyBuilder().addAll(Arrays.<Path>asList(able, baker)).build();
     Flow flow = new Flow(backstack);
     flow.setDispatcher(new FlowDispatcher());
     assertThat(backstack.size()).isEqualTo(2);
 
-    flow.resetTo(charlie);
+    flow.set(charlie);
     assertThat(lastStack.current()).isEqualTo(charlie);
     assertThat(lastStack.size()).isEqualTo(3);
     assertThat(lastDirection).isEqualTo(Flow.Direction.FORWARD);
@@ -229,14 +250,14 @@ public class FlowTest {
     assertThat(flow.goBack()).isFalse();
   }
 
-  @Test public void resetKeepsOriginal() {
+  @Test public void setPathKeepsOriginal() {
     Backstack backstack =
         Backstack.emptyBuilder().addAll(Arrays.<Path>asList(able, baker)).build();
     Flow flow = new Flow(backstack);
     flow.setDispatcher(new FlowDispatcher());
     assertThat(backstack.size()).isEqualTo(2);
 
-    flow.resetTo(new TestPath("Able"));
+    flow.set(new TestPath("Able"));
     assertThat(lastStack.current()).isEqualTo(new TestPath("Able"));
     assertThat(lastStack.current() == able).isTrue();
     assertThat(lastStack.current()).isSameAs(able);
@@ -244,7 +265,7 @@ public class FlowTest {
     assertThat(lastDirection).isEqualTo(Flow.Direction.BACKWARD);
   }
 
-  @Test public void replaceKeepsOriginals() {
+  @SuppressWarnings("deprecation") @Test public void replaceKeepsOriginals() {
     TestPath able = new Grandpa();
     TestPath baker = new Daddy();
     TestPath charlie = new Baby();
@@ -270,7 +291,7 @@ public class FlowTest {
     assertThat(lastStack.current()).isSameAs(able);
   }
 
-  @Test public void goUpKeepsOriginals() {
+  @SuppressWarnings("deprecation") @Test public void goUpKeepsOriginals() {
     TestPath able = new Grandpa();
     TestPath baker = new Daddy();
     TestPath charlie = new Baby();
@@ -317,7 +338,7 @@ public class FlowTest {
     }
   }
 
-  @Test public void resetCallsEquals() {
+  @Test public void setCallsEquals() {
     Backstack backstack = Backstack.emptyBuilder()
         .addAll(Arrays.<Path>asList(new Picky("Able"), new Picky("Baker"), new Picky("Charlie"),
             new Picky("Delta")))
@@ -327,7 +348,7 @@ public class FlowTest {
 
     assertThat(backstack.size()).isEqualTo(4);
 
-    flow.resetTo(new Picky("Charlie"));
+    flow.set(new Picky("Charlie"));
     assertThat(lastStack.current()).isEqualTo(new Picky("Charlie"));
     assertThat(lastStack.size()).isEqualTo(3);
     assertThat(lastDirection).isEqualTo(Flow.Direction.BACKWARD);
@@ -343,7 +364,7 @@ public class FlowTest {
     assertThat(flow.goBack()).isFalse();
   }
 
-  @Test public void replaceWithNonUppy() {
+  @SuppressWarnings("deprecation") @Test public void replaceWithNonUppy() {
     Backstack backstack = Backstack.emptyBuilder()
         .addAll(Arrays.<Path>asList(new Picky("Able"), new Picky("Baker"), new Picky("Charlie"),
             new Picky("Delta")))
@@ -360,7 +381,7 @@ public class FlowTest {
   /**
    * Sometimes its nice to jump into a new flow at a midpoint.
    */
-  @Test public void buildFromUp() {
+  @SuppressWarnings("deprecation") @Test public void buildFromUp() {
     Backstack backstack = Backstack.fromUpChain(new Tres());
     assertThat(backstack.size()).isEqualTo(3);
 
@@ -385,6 +406,7 @@ public class FlowTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   static class Daddy extends TestPath implements HasParent {
     Daddy() {
       super("Daddy");
@@ -395,6 +417,7 @@ public class FlowTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   static class Baby extends TestPath implements HasParent {
     Baby() {
       super("Baby");
@@ -405,6 +428,7 @@ public class FlowTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   static class Echo extends TestPath implements HasParent {
     Echo() {
       super("Echo");
@@ -415,6 +439,7 @@ public class FlowTest {
     }
   }
 
+  @SuppressWarnings("deprecation")
   static class Foxtrot extends TestPath implements HasParent {
     Foxtrot() {
       super("Foxtrot");

--- a/flow/src/test/java/flow/ReentranceTest.java
+++ b/flow/src/test/java/flow/ReentranceTest.java
@@ -18,11 +18,11 @@ package flow;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.fest.assertions.api.Assertions;
 import org.junit.Test;
 
+import static flow.Flow.Direction.FORWARD;
 import static flow.Flow.Traversal;
 import static flow.Flow.TraversalCallback;
 import static org.fest.assertions.api.Assertions.assertThat;
@@ -39,16 +39,16 @@ public class ReentranceTest {
         lastStack = navigation.destination;
         Object next = navigation.destination.current();
         if (next instanceof Detail) {
-          flow.goTo(new Loading());
+          flow.set(new Loading());
         } else if (next instanceof Loading) {
-          flow.goTo(new Error());
+          flow.set(new Error());
         }
         callback.onTraversalCompleted();
       }
     };
     flow = new Flow(Backstack.single(new Catalog()));
     flow.setDispatcher(dispatcher);
-    flow.goTo(new Detail());
+    flow.set(new Detail());
     verifyBackstack(lastStack, new Error(), new Loading(), new Detail(), new Catalog());
   }
 
@@ -61,9 +61,9 @@ public class ReentranceTest {
         Object next = navigation.destination.current();
         if (loading) {
           if (next instanceof Detail) {
-            flow.goTo(new Loading());
+            flow.set(new Loading());
           } else if (next instanceof Loading) {
-            flow.goTo(new Error());
+            flow.set(new Error());
           } else if (next instanceof Error) {
             loading = false;
             flow.goBack();
@@ -78,7 +78,7 @@ public class ReentranceTest {
     };
     flow = new Flow(Backstack.single(new Catalog()));
     flow.setDispatcher(dispatcher);
-    flow.goTo(new Detail());
+    flow.set(new Detail());
     verifyBackstack(lastStack, new Detail(), new Catalog());
   }
 
@@ -89,16 +89,17 @@ public class ReentranceTest {
         lastStack = traversal.destination;
         Object next = traversal.destination.current();
         if (next instanceof Detail) {
-          ReentranceTest.this.flow.forward(
-              Backstack.emptyBuilder().push(new Detail()).push(new Loading()).build());
+          ReentranceTest.this.flow.set(
+              Backstack.emptyBuilder().push(new Detail()).push(new Loading()).build(),
+              FORWARD);
         } else if (next instanceof Loading) {
-          ReentranceTest.this.flow.goTo(new Error());
+          ReentranceTest.this.flow.set(new Error());
         }
         callback.onTraversalCompleted();
       }
     });
     this.flow = flow;
-    flow.goTo(new Detail());
+    flow.set(new Detail());
     verifyBackstack(lastStack, new Error(), new Loading(), new Detail());
   }
 
@@ -109,9 +110,9 @@ public class ReentranceTest {
         lastCallback = callback;
         Object next = traversal.destination.current();
         if (next instanceof Detail) {
-          flow.goTo(new Loading());
+          flow.set(new Loading());
         } else if (next instanceof Loading) {
-          flow.goTo(new Error());
+          flow.set(new Error());
         }
       }
     };
@@ -119,7 +120,7 @@ public class ReentranceTest {
     flow.setDispatcher(dispatcher);
     lastCallback.onTraversalCompleted();
 
-    flow.goTo(new Detail());
+    flow.set(new Detail());
     verifyBackstack(flow.getBackstack(), new Catalog());
     lastCallback.onTraversalCompleted();
     verifyBackstack(flow.getBackstack(), new Detail(), new Catalog());
@@ -163,7 +164,7 @@ public class ReentranceTest {
   @Test public void pendingTraversalReplacesBootstrap() {
     final AtomicInteger dispatchCount = new AtomicInteger(0);
     flow = new Flow(Backstack.single(new Catalog()));
-    flow.goTo(new Detail());
+    flow.set(new Detail());
 
     flow.setDispatcher(new Flow.Dispatcher() {
       @Override public void dispatch(Traversal traversal, TraversalCallback callback) {
@@ -179,9 +180,9 @@ public class ReentranceTest {
 
   @Test public void allPendingTraversalsFire() {
     flow = new Flow(Backstack.single(new Catalog()));
-    flow.goTo(new Loading());
-    flow.goTo(new Detail());
-    flow.goTo(new Error());
+    flow.set(new Loading());
+    flow.set(new Detail());
+    flow.set(new Error());
 
     flow.setDispatcher(new Flow.Dispatcher() {
       @Override public void dispatch(Traversal traversal, TraversalCallback callback) {
@@ -201,7 +202,7 @@ public class ReentranceTest {
 
     flow.setDispatcher(new Flow.Dispatcher() {
       @Override public void dispatch(Traversal traversal, TraversalCallback callback) {
-        flow.goTo(new Loading());
+        flow.set(new Loading());
         flow.removeDispatcher(this);
         callback.onTraversalCompleted();
       }
@@ -242,7 +243,7 @@ public class ReentranceTest {
     flow = new Flow(Backstack.single(new Catalog()));
     flow.setDispatcher(new Flow.Dispatcher() {
       @Override public void dispatch(Traversal traversal, TraversalCallback callback) {
-        flow.goTo(new Detail());
+        flow.set(new Detail());
         lastCallback = callback;
       }
     });
@@ -268,7 +269,7 @@ public class ReentranceTest {
       @Override public void dispatch(Traversal traversal, TraversalCallback callback) {
         lastCallback = callback;
         flow.removeDispatcher(this);
-        flow.goTo(new Loading());
+        flow.set(new Loading());
       }
     });
 


### PR DESCRIPTION
If we'd had a 1.0, this would be 2.0.

The old API was ambiguous and confusing. Use of `goTo` could easily lead
to unintentionally having the same path on the backstack twice. The
difference between `resetTo` and `replaceTo` was not easy to understand
and the two were easily confused.

Those three methods are all now deprecated (along with the previously
deprecated goUp), and there are two new methods to replace them:

- `set(Path)` will make the given path the top of your backstack,
  inferring push or pop operations and dispatching with the inferred
  Direction. This is your Just Go Here option.

- `set(Backstack, Direction)` will simply throw away the current
  backstack, install the given backstack, and dispatch with the given
  direction. This is your Total Control option.