### PR TITLE
rename set(Backstack, Direction) to setBackstack

### DIFF
--- a/flow/src/main/java/flow/ActivityFlowSupport.java
+++ b/flow/src/main/java/flow/ActivityFlowSupport.java
@@ -105,7 +105,7 @@ public final class ActivityFlowSupport {
     checkArgument(intent != null, "intent may not be null");
     if (intent.hasExtra(BACKSTACK_KEY)) {
       Backstack backstack = Backstack.from(intent.getParcelableExtra(BACKSTACK_KEY), parceler);
-      flow.set(backstack, Flow.Direction.REPLACE);
+      flow.setBackstack(backstack, Flow.Direction.REPLACE);
     }
   }
 

--- a/flow/src/main/java/flow/Flow.java
+++ b/flow/src/main/java/flow/Flow.java
@@ -104,7 +104,7 @@ public final class Flow {
       // Nothing is happening;
       // OR, there is an outstanding callback and nothing will happen after it;
       // So enqueue a bootstrap traversal.
-      set(backstack, Direction.REPLACE);
+      setBackstack(backstack, Direction.REPLACE);
       return;
     }
 
@@ -135,7 +135,7 @@ public final class Flow {
   /**
    * Replaces the backstack with the one given and dispatches in the given direction.
    */
-  public void set(final Backstack backstack, final Direction direction) {
+  public void setBackstack(final Backstack backstack, final Direction direction) {
     move(new PendingTraversal() {
       @Override void doExecute() {
         dispatch(backstack, direction);
@@ -217,7 +217,7 @@ public final class Flow {
   }
 
   /**
-   * @deprecated Use {@link #set(Backstack, Direction)}.
+   * @deprecated Use {@link #setBackstack(Backstack, Direction)}.
    */
   @Deprecated  @SuppressWarnings("deprecation") public void replaceTo(final Path path) {
     move(new PendingTraversal() {
@@ -232,7 +232,7 @@ public final class Flow {
    * Go up one screen.
    *
    * @return false if going up is not possible.
-   * @deprecated Use {@link #set(Backstack, Direction)}
+   * @deprecated Use {@link #setBackstack(Backstack, Direction)}
    */
   @Deprecated @SuppressWarnings("deprecation") public boolean goUp() {
     boolean canGoUp = false;
@@ -285,21 +285,21 @@ public final class Flow {
   /**
    * Goes forward to a new backstack.
    *
-   * @deprecated Use {@link #set(Backstack, Direction)}
+   * @deprecated Use {@link #setBackstack(Backstack, Direction)}
    */
   @Deprecated @SuppressWarnings("UnusedDeclaration")
   public void forward(final Backstack newBackstack) {
-    set(newBackstack, Direction.FORWARD);
+    setBackstack(newBackstack, Direction.FORWARD);
   }
 
   /**
    * Goes backward to a new backstack.
    *
-   * @deprecated Use {@link #set(Backstack, Direction)}
+   * @deprecated Use {@link #setBackstack(Backstack, Direction)}
    */
   @Deprecated @SuppressWarnings("UnusedDeclaration")
   public void backward(final Backstack newBackstack) {
-    set(newBackstack, Direction.BACKWARD);
+    setBackstack(newBackstack, Direction.BACKWARD);
   }
 
   private void move(PendingTraversal pendingTraversal) {

--- a/flow/src/test/java/flow/FlowTest.java
+++ b/flow/src/test/java/flow/FlowTest.java
@@ -196,7 +196,7 @@ public class FlowTest {
 
     Backstack newBackstack = Backstack.emptyBuilder().addAll(
         Arrays.<Path>asList(charlie, delta)).build();
-    flow.set(newBackstack, Flow.Direction.FORWARD);
+    flow.setBackstack(newBackstack, Flow.Direction.FORWARD);
     assertThat(lastDirection).isSameAs(Flow.Direction.FORWARD);
     assertThat(lastStack.current()).isSameAs(delta);
     assertThat(flow.goBack()).isTrue();

--- a/flow/src/test/java/flow/ReentranceTest.java
+++ b/flow/src/test/java/flow/ReentranceTest.java
@@ -89,9 +89,8 @@ public class ReentranceTest {
         lastStack = traversal.destination;
         Object next = traversal.destination.current();
         if (next instanceof Detail) {
-          ReentranceTest.this.flow.set(
-              Backstack.emptyBuilder().push(new Detail()).push(new Loading()).build(),
-              FORWARD);
+          ReentranceTest.this.flow.setBackstack(
+              Backstack.emptyBuilder().push(new Detail()).push(new Loading()).build(), FORWARD);
         } else if (next instanceof Loading) {
           ReentranceTest.this.flow.set(new Error());
         }


### PR DESCRIPTION
Overloading a method that takes Object as its only parameter is not a
very good affordance, leads to accidental up-casts.