### PR TITLE
Fix view state persistence

### DIFF
--- a/flow-sample/src/main/java/com/example/flow/MainActivity.java
+++ b/flow-sample/src/main/java/com/example/flow/MainActivity.java
@@ -64,16 +64,13 @@ public class MainActivity extends Activity implements Flow.Dispatcher {
     GsonParceler parceler = new GsonParceler(new Gson());
     @SuppressWarnings("deprecation") ActivityFlowSupport.NonConfigurationInstance nonConfig =
         (ActivityFlowSupport.NonConfigurationInstance) getLastNonConfigurationInstance();
-    flowSupport = ActivityFlowSupport.onCreate(nonConfig, getIntent(), savedInstanceState, parceler,
-        Backstack.single(new Paths.ConversationList()));
-
     final ActionBar actionBar = getActionBar();
     actionBar.setDisplayShowHomeEnabled(false);
-
     setContentView(R.layout.root_layout);
-
     container = (PathContainerView) findViewById(R.id.container);
     containerAsBackTarget = (HandlesBack) container;
+    flowSupport = ActivityFlowSupport.onCreate(nonConfig, getIntent(), savedInstanceState, parceler,
+        Backstack.single(new Paths.ConversationList()), this);
   }
 
   @Override protected void onNewIntent(Intent intent) {
@@ -83,7 +80,7 @@ public class MainActivity extends Activity implements Flow.Dispatcher {
 
   @Override protected void onResume() {
     super.onResume();
-    flowSupport.onResume(this);
+    flowSupport.onResume();
   }
 
   @Override protected void onPause() {

--- a/flow-sample/src/main/java/com/example/flow/view/FriendView.java
+++ b/flow-sample/src/main/java/com/example/flow/view/FriendView.java
@@ -18,7 +18,7 @@ package com.example.flow.view;
 
 import android.content.Context;
 import android.util.AttributeSet;
-import android.widget.FrameLayout;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 import butterknife.ButterKnife;
 import butterknife.InjectView;
@@ -30,7 +30,7 @@ import flow.path.Path;
 import java.util.List;
 import javax.inject.Inject;
 
-public class FriendView extends FrameLayout {
+public class FriendView extends LinearLayout {
   @Inject List<User> friends;
 
   private final User friend;

--- a/flow-sample/src/main/res/layout/friend_view.xml
+++ b/flow-sample/src/main/res/layout/friend_view.xml
@@ -20,11 +20,19 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     android:id="@+id/friend_view"
     >
   <TextView
       android:id="@+id/friend_info"
       android:layout_width="match_parent"
-      android:layout_height="match_parent"
+      android:layout_height="wrap_content"
+      />
+  <EditText
+      android:id="@+id/friend_note"
+      android:freezesText="true"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:minLines="2"
       />
 </com.example.flow.view.FriendView>

--- a/flow/src/main/java/flow/ActivityFlowSupport.java
+++ b/flow/src/main/java/flow/ActivityFlowSupport.java
@@ -2,10 +2,9 @@ package flow;
 
 import android.content.Intent;
 import android.os.Bundle;
-import java.util.Iterator;
+import android.os.Parcelable;
 
 import static flow.Preconditions.checkArgument;
-import static flow.Preconditions.checkState;
 
 /**
  * Manages a Flow within an Activity.  Make sure that each method is called from the corresponding
@@ -79,14 +78,18 @@ public final class ActivityFlowSupport {
   private final Parceler parceler;
   private final Flow flow;
   private Flow.Dispatcher dispatcher;
+  private boolean dispatcherSet;
 
-  private ActivityFlowSupport(Flow flow, Parceler parceler) {
+  private ActivityFlowSupport(Flow flow, Flow.Dispatcher dispatcher, Parceler parceler) {
     this.flow = flow;
+    this.dispatcher = dispatcher;
     this.parceler = parceler;
   }
 
+  /** Immediately starts the Dispatcher, so the dispatcher should be prepared before calling. */
   public static ActivityFlowSupport onCreate(NonConfigurationInstance nonConfigurationInstance,
-      Intent intent, Bundle savedInstanceState, Parceler parceler, Backstack defaultBackstack) {
+      Intent intent, Bundle savedInstanceState, Parceler parceler, Backstack defaultBackstack,
+      Flow.Dispatcher dispatcher) {
     checkArgument(parceler != null, "parceler may not be null");
     final Flow flow;
     if (nonConfigurationInstance != null) {
@@ -98,7 +101,8 @@ public final class ActivityFlowSupport {
       }
       flow = new Flow(selectBackstack(intent, savedBackstack, defaultBackstack, parceler));
     }
-    return new ActivityFlowSupport(flow, parceler);
+    flow.setDispatcher(dispatcher);
+    return new ActivityFlowSupport(flow, dispatcher, parceler);
   }
 
   public void onNewIntent(Intent intent) {
@@ -109,11 +113,11 @@ public final class ActivityFlowSupport {
     }
   }
 
-  public void onResume(Flow.Dispatcher dispatcher) {
-    checkArgument(dispatcher != null, "dispatcher may not be null");
-    this.dispatcher = dispatcher;
-
-    flow.setDispatcher(dispatcher);
+  public void onResume() {
+    if (!dispatcherSet) {
+      dispatcherSet = true;
+      flow.setDispatcher(dispatcher);
+    }
   }
 
   public NonConfigurationInstance onRetainNonConfigurationInstance() {
@@ -121,9 +125,8 @@ public final class ActivityFlowSupport {
   }
 
   public void onPause() {
-    checkState(dispatcher != null, "Did you forget to call onResume()?");
     flow.removeDispatcher(dispatcher);
-    dispatcher = null;
+    dispatcherSet = false;
   }
 
   /**
@@ -135,10 +138,15 @@ public final class ActivityFlowSupport {
 
   public void onSaveInstanceState(Bundle outState) {
     checkArgument(outState != null, "outState may not be null");
-    Backstack backstack = getBackstackToSave(flow.getBackstack());
-    if (backstack == null) return;
-    //noinspection ConstantConditions
-    outState.putParcelable(BACKSTACK_KEY, backstack.getParcelable(parceler));
+    Parcelable parcelable = flow.getBackstack().getParcelable(parceler, new Backstack.Filter() {
+      @Override public boolean apply(Object state) {
+        return !state.getClass().isAnnotationPresent(NotPersistent.class);
+      }
+    });
+    if (parcelable != null) {
+      //noinspection ConstantConditions
+      outState.putParcelable(BACKSTACK_KEY, parcelable);
+    }
   }
 
   /**
@@ -160,19 +168,5 @@ public final class ActivityFlowSupport {
       return saved;
     }
     return defaultBackstack;
-  }
-
-  private static Backstack getBackstackToSave(Backstack backstack) {
-    Iterator<Object> it = backstack.reverseIterator();
-    Backstack.Builder save = Backstack.emptyBuilder();
-    boolean empty = true;
-    while (it.hasNext()) {
-      Object state = it.next();
-      if (!state.getClass().isAnnotationPresent(NotPersistent.class)) {
-        save.push(state);
-        empty = false;
-      }
-    }
-    return empty ? null : save.build();
   }
 }


### PR DESCRIPTION
Thanks to Aleksey Malevaniy for catching these problems and
demonstrating fixes.

This change fixes two problems with view state persistence in
ActivityFlowSupport:

1. It was just throwing view state away when building the Parcelable to
save in the Bundle. The fix is to move filtering into Backstack itself,
so that it can build a Parcelable that includes view state.

2. It wasn (re)constructing the view hierarchy for the first time in
onResume(), which is after restoreHierarchyState() is called.  View
state was therefore not getting properly restored. The fix is to rebuild
the view hierarchy in onCreate(), so that it's there in time for
restoreHierarchyState().