### PR TITLE
History.Builder no longer loses internal state

### DIFF
--- a/flow-path/build.gradle
+++ b/flow-path/build.gradle
@@ -34,4 +34,6 @@ android.libraryVariants.all { variant ->
   }
 }
 
-apply from: '../gradle-mvn-push.gradle'
+if (hasProperty("POM_DEVELOPER_ID")) {
+  apply from: '../gradle-mvn-push.gradle'
+}

--- a/flow/build.gradle
+++ b/flow/build.gradle
@@ -33,4 +33,6 @@ android.libraryVariants.all { variant ->
   }
 }
 
-apply from: '../gradle-mvn-push.gradle'
+if (hasProperty("POM_DEVELOPER_ID")) {
+  apply from: '../gradle-mvn-push.gradle'
+}

--- a/flow/src/main/java/flow/Flow.java
+++ b/flow/src/main/java/flow/Flow.java
@@ -239,7 +239,7 @@ public final class Flow {
     Iterator<Object> oldIt = current.reverseIterator();
     Iterator<Object> newIt = proposed.reverseIterator();
 
-    History.Builder preserving = History.emptyBuilder();
+    History.Builder preserving = current.buildUpon().clear();
 
     while (newIt.hasNext()) {
       Object newEntry = newIt.next();


### PR DESCRIPTION
It is now safe to pop objects off of a builder and then push them back
onto the same builder without losing internal state.

Also added Builder#clear, a convenience method for clearing the stack
while preserving internal state.

Flow has been updated to use History appropriately to preserve state.