### PR TITLE
Navigation with Flow now destroys Mortar-scopes only if they are not found in the destination traversal

### DIFF
--- a/flow-path/src/main/java/flow/path/PathContainer.java
+++ b/flow-path/src/main/java/flow/path/PathContainer.java
@@ -117,6 +117,18 @@ public abstract class PathContainer {
         return;
       }
     }
+    
+    if(traversal.direction == Flow.Direction.FORWARD) {
+        Iterator<Object> destinationPaths = traversal.destination.reverseIterator();
+        int i = 1; // 0 is ROOT in PathContext, we need to merge destination paths after the ROOT without adding self-duplication
+        while(_destinationPaths.hasNext()) {
+            Path destinationPath = (Path) destinationPaths.next();
+            if(destinationPath != path) {
+                path.elements().add(i, destinationPath);
+            }
+            i++;
+        }
+    }
 
     traversalState.setNextEntry(path, viewState);
     performTraversal(container, traversalState, direction, callback);

--- a/flow-path/src/main/java/flow/path/PathContext.java
+++ b/flow-path/src/main/java/flow/path/PathContext.java
@@ -89,16 +89,16 @@ public final class PathContext extends ContextWrapper {
     Iterator<Path> aElements = this.path.elements().iterator();
     Iterator<Path> bElements = path.path.elements().iterator();
     while(aElements.hasNext() && bElements.hasNext()) {
-        Path aElement = aElements.next();
-        Path bElement = bElements.next();
-        if(!aElement.equals(bElement)) {
-            factory.tearDownContext(contexts.get(aElement));
-            break;
-        }
+      Path aElement = aElements.next();
+      Path bElement = bElements.next();
+      if(!aElement.equals(bElement)) {
+        factory.tearDownContext(contexts.get(aElement));
+        break;
+      }
     }
     while(aElements.hasNext()) {
-        Path aElement = aElements.next();
-        factory.tearDownContext(contexts.get(aElement));
+      Path aElement = aElements.next();
+      factory.tearDownContext(contexts.get(aElement));
     }
   }
 

--- a/flow-path/src/main/java/flow/path/PathContext.java
+++ b/flow-path/src/main/java/flow/path/PathContext.java
@@ -88,13 +88,17 @@ public final class PathContext extends ContextWrapper {
   public void destroyNotIn(PathContext path, PathContextFactory factory) {
     Iterator<Path> aElements = this.path.elements().iterator();
     Iterator<Path> bElements = path.path.elements().iterator();
-    while (aElements.hasNext() && bElements.hasNext()) {
-      Path aElement = aElements.next();
-      Path bElement = bElements.next();
-      if (!aElement.equals(bElement)) {
+    while(aElements.hasNext() && bElements.hasNext()) {
+        Path aElement = aElements.next();
+        Path bElement = bElements.next();
+        if(!aElement.equals(bElement)) {
+            factory.tearDownContext(contexts.get(aElement));
+            break;
+        }
+    }
+    while(aElements.hasNext()) {
+        Path aElement = aElements.next();
         factory.tearDownContext(contexts.get(aElement));
-        break;
-      }
     }
   }
 


### PR DESCRIPTION
This is the pull request with the fix for this following issue:
https://github.com/square/flow/issues/116

Please test to see if it works just fine on your side with the new Flow, although it works perfectly fine for me on 0.12 even through process death.