### PR TITLE
selectHistory should favor restoring history from instance state

### DIFF
--- a/flow/src/main/java/flow/InternalLifecycleIntegration.java
+++ b/flow/src/main/java/flow/InternalLifecycleIntegration.java
@@ -134,13 +134,13 @@ public final class InternalLifecycleIntegration extends Fragment {
 
   private static History selectHistory(Intent intent, History saved,
       History defaultHistory, @Nullable StateParceler parceler) {
+    if (saved != null) {
+      return saved;
+    }
     if (intent != null && intent.hasExtra(Flow.HISTORY_KEY)) {
       checkNotNull(parceler,
           "Intent has a Flow history extra, but Flow was not installed with a StateParceler");
       return History.from(intent.getParcelableExtra(Flow.HISTORY_KEY), parceler);
-    }
-    if (saved != null) {
-      return saved;
     }
     return defaultHistory;
   }


### PR DESCRIPTION
selectHistory currently favors history from an Intent bundle over history from the Activity instance state.  It should only consider the history from the activity Intent if there is nothing to restore.