### PR TITLE
introduce MultiKeys

### DIFF
--- a/flow/src/main/java/flow/MultiKey.java
+++ b/flow/src/main/java/flow/MultiKey.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package flow;
+
+import java.util.List;
+
+/**
+ * A key composed of keys.
+ *
+ * Component keys may be ordinary objects, {@link TreeKey}s, or MultiKeys.
+ */
+public interface MultiKey {
+  List<Object> getKeys();
+}


### PR DESCRIPTION
**Needs retarget to master after #129 lands**

A MultiKey represents an aggregate of keys, including TreeKeys.

A MultiKey may not itself be an element in a TreeKey.