### PR TITLE
Safer History manipulations

### DIFF
--- a/flow-sample-basic/src/main/java/flow/sample/basic/BasicDispatcher.java
+++ b/flow-sample-basic/src/main/java/flow/sample/basic/BasicDispatcher.java
@@ -40,7 +40,7 @@ final class BasicDispatcher implements Flow.Dispatcher {
 
     if (traversal.origin != null) {
       if (frame.getChildCount() > 0) {
-        traversal.origin.topSaveState().save(frame.getChildAt(0));
+        traversal.getState(traversal.origin.top()).save(frame.getChildAt(0));
         frame.removeAllViews();
       }
     }
@@ -58,7 +58,7 @@ final class BasicDispatcher implements Flow.Dispatcher {
         .inflate(layout, frame, false);
 
     frame.addView(incomingView);
-    traversal.destination.topSaveState().restore(incomingView);
+    traversal.getState(traversal.destination.top()).restore(incomingView);
 
     callback.onTraversalCompleted();
   }

--- a/flow/src/main/java/flow/Flow.java
+++ b/flow/src/main/java/flow/Flow.java
@@ -36,8 +36,6 @@ public final class Flow {
     }
   };
 
-  static final String HISTORY_KEY = InternalLifecycleIntegration.class.getSimpleName() + "_history";
-
   public static Flow get(View view) {
     return get(view.getContext());
   }
@@ -71,7 +69,7 @@ public final class Flow {
 
   /** Adds a history as an extra to an Intent. */
   public static void addHistory(Intent intent, History history, KeyParceler parceler) {
-    intent.putExtra(HISTORY_KEY, history.getParcelable(parceler));
+    InternalLifecycleIntegration.addHistoryToIntent(intent, history, parceler);
   }
 
   /**
@@ -81,7 +79,7 @@ public final class Flow {
    */
   public static boolean onNewIntent(Intent intent, Activity activity) {
     checkArgument(intent != null, "intent may not be null");
-    if (intent.hasExtra(HISTORY_KEY)) {
+    if (intent.hasExtra(InternalLifecycleIntegration.INTENT_KEY)) {
       InternalLifecycleIntegration.find(activity).onNewIntent(intent);
       return true;
     }
@@ -125,6 +123,10 @@ public final class Flow {
      */
     public Context createContext(Object key, Context baseContext) {
       return new FlowContextWrapper(keyManager.findServices(key), baseContext);
+    }
+
+    public State getState(Object key) {
+      return keyManager.getState(key);
     }
   }
 
@@ -376,6 +378,7 @@ public final class Flow {
           keyManager.tearDown(it.next());
           it.remove();
         }
+        keyManager.clearStatesExcept(history.asList());
       } else if (dispatcher != null) {
         pendingTraversal.execute();
       }

--- a/flow/src/main/java/flow/History.java
+++ b/flow/src/main/java/flow/History.java
@@ -198,7 +198,7 @@ public final class History implements Iterable<Object> {
     /**
      * {@link #push Pushes} all of the keys in the collection onto this builder.
      */
-    public Builder addAll(Collection<?> c) {
+    public Builder pushAll(Collection<?> c) {
       for (Object key : c) {
         push(key);
       }

--- a/flow/src/main/java/flow/History.java
+++ b/flow/src/main/java/flow/History.java
@@ -16,84 +16,27 @@
 
 package flow;
 
-import android.os.Bundle;
-import android.os.Parcelable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
-import java.util.Map;
 
 import static flow.Preconditions.checkArgument;
+import static java.util.Collections.unmodifiableList;
 
 /**
  * Describes the history of a {@link Flow} at a specific point in time.
  */
 public final class History implements Iterable<Object> {
-  public interface Filter {
-    boolean apply(Object key);
-  }
 
-  /** Restore a saved history from a {@link Parcelable} using the supplied {@link KeyParceler}. */
-  public static History from(Parcelable parcelable, KeyParceler parceler) {
-    Bundle bundle = (Bundle) parcelable;
-    ArrayList<Bundle> entryBundles = bundle.getParcelableArrayList("ENTRIES");
-    if (entryBundles == null) throw new AssertionError("Parcelable does not contain history");
-    List<State> entries = new ArrayList<>(entryBundles.size());
-    for (Bundle entryBundle : entryBundles) {
-      entries.add(State.fromBundle(entryBundle, parceler));
-    }
-    return new History(entries);
-  }
-
-  private final List<State> history;
-
-  /** Get a {@link Parcelable} of this history using the supplied {@link KeyParceler}. */
-  public Parcelable getParcelable(KeyParceler parceler) {
-    Bundle historyBundle = new Bundle();
-    ArrayList<Bundle> entryBundles = new ArrayList<>(history.size());
-    for (State entry : history) {
-      entryBundles.add(entry.toBundle(parceler));
-    }
-    if (entryBundles.isEmpty()) {
-      return null;
-    }
-    historyBundle.putParcelableArrayList("ENTRIES", entryBundles);
-    return historyBundle;
-  }
-
-  /**
-   * Get a {@link Parcelable} of this history using the supplied {@link KeyParceler}, filtered
-   * by the supplied {@link Filter}.
-   *
-   * The filter is invoked on each key in the stack in reverse order
-   *
-   * @return null if all keys are filtered out.
-   */
-  public Parcelable getParcelable(KeyParceler parceler, Filter filter) {
-    Bundle historyBundle = new Bundle();
-    ArrayList<Bundle> entryBundles = new ArrayList<>(history.size());
-    ListIterator<State> it = history.listIterator();
-    while (it.hasNext()) {
-      State entry = it.next();
-      if (filter.apply(entry.getKey())) {
-        entryBundles.add(entry.toBundle(parceler));
-      }
-    }
-    if (entryBundles.isEmpty()) {
-      return null;
-    }
-    historyBundle.putParcelableArrayList("ENTRIES", entryBundles);
-    return historyBundle;
-  }
+  private final List<Object> history;
 
   public static Builder emptyBuilder() {
-    return new Builder(Collections.<State>emptyList());
+    return new Builder(Collections.emptyList());
   }
 
   /** Create a history that contains a single key. */
@@ -101,7 +44,7 @@ public final class History implements Iterable<Object> {
     return emptyBuilder().push(key).build();
   }
 
-  private History(List<State> history) {
+  private History(List<Object> history) {
     checkArgument(history != null && !history.isEmpty(), "History may not be empty");
     this.history = history;
   }
@@ -119,25 +62,18 @@ public final class History implements Iterable<Object> {
   }
 
   public <T> T top() {
-    //noinspection unchecked
-    return (T) peekSaveState(0).getKey();
+    return peek(0);
   }
 
   /** Returns the app state at the provided index in history. 0 is the newest entry. */
   public <T> T peek(int index) {
     //noinspection unchecked
-    return (T) peekSaveState(index).getKey();
+    return (T) history.get(history.size() - index - 1);
   }
 
-  /**
-   * Returns the {@link State} at the provided index in history. 0 is the newest entry.
-   */
-  public State peekSaveState(int index) {
-    return history.get(history.size() - index - 1);
-  }
-
-  public State topSaveState() {
-    return peekSaveState(0);
+  List<Object> asList() {
+    final ArrayList<Object> copy = new ArrayList<>(history);
+    return unmodifiableList(copy);
   }
 
   /**
@@ -156,10 +92,9 @@ public final class History implements Iterable<Object> {
   }
 
   public static final class Builder {
-    private final List<State> history;
-    private final Map<Object, State> entryMemory = new LinkedHashMap<>();
+    private final List<Object> history;
 
-    private Builder(Collection<State> history) {
+    private Builder(Collection<Object> history) {
       this.history = new ArrayList<>(history);
     }
 
@@ -185,13 +120,7 @@ public final class History implements Iterable<Object> {
      * from the builder, the key's associated state will be restored.
      */
     public Builder push(Object key) {
-      State entry = entryMemory.get(key);
-      if (entry == null) {
-        final Object key1 = key;
-        entry = new State(key1);
-      }
-      history.add(entry);
-      entryMemory.remove(key);
+      history.add(key);
       return this;
     }
 
@@ -206,7 +135,7 @@ public final class History implements Iterable<Object> {
     }
 
     public Object peek() {
-      return history.isEmpty() ? null : history.get(history.size() - 1).getKey();
+      return history.isEmpty() ? null : history.get(history.size() - 1);
     }
 
     public boolean isEmpty() {
@@ -225,9 +154,7 @@ public final class History implements Iterable<Object> {
       if (isEmpty()) {
         throw new IllegalStateException("Cannot pop from an empty builder");
       }
-      State entry = history.remove(history.size() - 1);
-      entryMemory.put(entry.getKey(), entry);
-      return entry.getKey();
+      return history.remove(history.size() - 1);
     }
 
     /**
@@ -284,9 +211,9 @@ public final class History implements Iterable<Object> {
   }
 
   private static class ReadStateIterator<T> implements Iterator<T> {
-    private final Iterator<State> iterator;
+    private final Iterator<Object> iterator;
 
-    ReadStateIterator(Iterator<State> iterator) {
+    ReadStateIterator(Iterator<Object> iterator) {
       this.iterator = iterator;
     }
 
@@ -296,7 +223,7 @@ public final class History implements Iterable<Object> {
 
     @Override public T next() {
       //noinspection unchecked
-      return (T) iterator.next().getKey();
+      return (T) iterator.next();
     }
 
     @Override public void remove() {

--- a/flow/src/main/java/flow/KeyDispatcher.java
+++ b/flow/src/main/java/flow/KeyDispatcher.java
@@ -61,12 +61,12 @@ public final class KeyDispatcher implements Flow.Dispatcher {
   }
 
   @Override public void dispatch(Flow.Traversal traversal, Flow.TraversalCallback callback) {
-    State inState = traversal.destination.topSaveState();
+    State inState = traversal.getState(traversal.destination.top());
     Object inKey = inState.getKey();
-    State outState = traversal.origin == null ? null : traversal.origin.topSaveState();
+    State outState = traversal.origin == null ? null : traversal.getState(traversal.origin.top());
     Object outKey = outState == null ? null : outState.getKey();
 
-    // TODO(#126): this short-circuit may belong in Flow, since every Dispatcher we have implements it.
+    // TODO(#126): short-circuit may belong in Flow, since every Dispatcher we have implements it.
     if (inKey.equals(outKey)) {
       callback.onTraversalCompleted();
       return;

--- a/flow/src/main/java/flow/KeyManager.java
+++ b/flow/src/main/java/flow/KeyManager.java
@@ -19,6 +19,7 @@ package flow;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,11 +31,39 @@ class KeyManager {
     }
   };
   private final Map<Object, ManagedServices> managedServices = new LinkedHashMap<>();
+  private final Map<Object, State> states = new LinkedHashMap<>();
+
   private final List<ServicesFactory> servicesFactories = new ArrayList<>();
 
   KeyManager(List<ServicesFactory> servicesFactories) {
     this.servicesFactories.addAll(servicesFactories);
     managedServices.put(ROOT_KEY, new ManagedServices(Services.ROOT_SERVICES));
+  }
+
+
+  boolean hasState(Object key) {
+    return states.containsKey(key);
+  }
+
+  void addState(State state) {
+    states.put(state.getKey(), state);
+  }
+
+  State getState(Object key) {
+    State state = states.get(key);
+    if (state == null) {
+      state = new State(key);
+      addState(state);
+    }
+    return state;
+  }
+
+  void clearStatesExcept(List<Object> keep) {
+    Iterator<Object> keys = states.keySet().iterator();
+    while (keys.hasNext()) {
+      final Object key = keys.next();
+      if (!keep.contains(key)) keys.remove();
+    }
   }
 
   Services findServices(Object key) {

--- a/flow/src/main/java/flow/State.java
+++ b/flow/src/main/java/flow/State.java
@@ -37,7 +37,7 @@ public class State {
   }
 
   private final Object key;
-  private Bundle bundle;
+  @Nullable private Bundle bundle;
   @Nullable SparseArray<Parcelable> viewState;
 
   State(Object key) {
@@ -66,15 +66,19 @@ public class State {
     this.bundle = bundle;
   }
 
-  @Nullable public Bundle toBundle() {
+  @Nullable public Bundle getBundle() {
     return bundle;
   }
 
   Bundle toBundle(KeyParceler parceler) {
     Bundle outState = new Bundle();
     outState.putParcelable("KEY", parceler.toParcelable(getKey()));
-    outState.putSparseParcelableArray("VIEW_STATE", viewState);
-    outState.putBundle("BUNDLE", bundle);
+    if (viewState != null && viewState.size() > 0) {
+      outState.putSparseParcelableArray("VIEW_STATE", viewState);
+    }
+    if (bundle != null && !bundle.isEmpty()) {
+      outState.putBundle("BUNDLE", bundle);
+    }
     return outState;
   }
 
@@ -107,7 +111,7 @@ public class State {
     @Override public void setBundle(Bundle bundle) {
     }
 
-    @Nullable @Override public Bundle toBundle() {
+    @Nullable @Override public Bundle getBundle() {
       return null;
     }
   }

--- a/flow/src/test/java/flow/FlowTest.java
+++ b/flow/src/test/java/flow/FlowTest.java
@@ -105,9 +105,9 @@ public class FlowTest {
     listener.flow.set(new Dos());
   }
 
-  @Test public void historyAddAllIsPushy() {
+  @Test public void historyPushAllIsPushy() {
     History history =
-        History.emptyBuilder().addAll(Arrays.<Object>asList(able, baker, charlie)).build();
+        History.emptyBuilder().pushAll(Arrays.<Object>asList(able, baker, charlie)).build();
     assertThat(history.size()).isEqualTo(3);
 
     Flow flow = new Flow(keyManager, history);
@@ -123,13 +123,13 @@ public class FlowTest {
   }
 
   @Test public void setHistoryWorks() {
-    History history = History.emptyBuilder().addAll(Arrays.<Object>asList(able, baker)).build();
+    History history = History.emptyBuilder().pushAll(Arrays.<Object>asList(able, baker)).build();
     Flow flow = new Flow(keyManager, history);
     FlowDispatcher dispatcher = new FlowDispatcher();
     flow.setDispatcher(dispatcher);
 
     History newHistory =
-        History.emptyBuilder().addAll(Arrays.<Object>asList(charlie, delta)).build();
+        History.emptyBuilder().pushAll(Arrays.<Object>asList(charlie, delta)).build();
     flow.setHistory(newHistory, Flow.Direction.FORWARD);
     assertThat(lastDirection).isSameAs(Flow.Direction.FORWARD);
     assertThat(lastStack.top()).isSameAs(delta);
@@ -140,7 +140,7 @@ public class FlowTest {
 
   @Test public void setObjectGoesBack() {
     History history =
-        History.emptyBuilder().addAll(Arrays.<Object>asList(able, baker, charlie, delta)).build();
+        History.emptyBuilder().pushAll(Arrays.<Object>asList(able, baker, charlie, delta)).build();
     Flow flow = new Flow(keyManager, history);
     flow.setDispatcher(new FlowDispatcher());
 
@@ -163,7 +163,7 @@ public class FlowTest {
   }
 
   @Test public void setObjectToMissingObjectPushes() {
-    History history = History.emptyBuilder().addAll(Arrays.<Object>asList(able, baker)).build();
+    History history = History.emptyBuilder().pushAll(Arrays.<Object>asList(able, baker)).build();
     Flow flow = new Flow(keyManager, history);
     flow.setDispatcher(new FlowDispatcher());
     assertThat(history.size()).isEqualTo(2);
@@ -184,7 +184,7 @@ public class FlowTest {
   }
 
   @Test public void setObjectKeepsOriginal() {
-    History history = History.emptyBuilder().addAll(Arrays.<Object>asList(able, baker)).build();
+    History history = History.emptyBuilder().pushAll(Arrays.<Object>asList(able, baker)).build();
     Flow flow = new Flow(keyManager, history);
     flow.setDispatcher(new FlowDispatcher());
     assertThat(history.size()).isEqualTo(2);
@@ -203,7 +203,7 @@ public class FlowTest {
     TestState charlie = new TestState("Charlie");
     TestState delta = new TestState("Delta");
     History history =
-        History.emptyBuilder().addAll(Arrays.<Object>asList(able, baker, charlie, delta)).build();
+        History.emptyBuilder().pushAll(Arrays.<Object>asList(able, baker, charlie, delta)).build();
     Flow flow = new Flow(keyManager, history);
     flow.setDispatcher(new FlowDispatcher());
     assertThat(history.size()).isEqualTo(4);
@@ -211,7 +211,7 @@ public class FlowTest {
     TestState echo = new TestState("Echo");
     TestState foxtrot = new TestState("Foxtrot");
     History newHistory =
-        History.emptyBuilder().addAll(Arrays.<Object>asList(able, baker, echo, foxtrot)).build();
+        History.emptyBuilder().pushAll(Arrays.<Object>asList(able, baker, echo, foxtrot)).build();
     flow.setHistory(newHistory, Flow.Direction.REPLACE);
     assertThat(lastStack.size()).isEqualTo(4);
     assertThat(lastStack.top()).isEqualTo(foxtrot);
@@ -248,7 +248,7 @@ public class FlowTest {
 
   @Test public void setCallsEquals() {
     History history = History.emptyBuilder()
-        .addAll(Arrays.<Object>asList(new Picky("Able"), new Picky("Baker"), new Picky("Charlie"),
+        .pushAll(Arrays.<Object>asList(new Picky("Able"), new Picky("Baker"), new Picky("Charlie"),
             new Picky("Delta")))
         .build();
     Flow flow = new Flow(keyManager, history);

--- a/flow/src/test/java/flow/HistoryTest.java
+++ b/flow/src/test/java/flow/HistoryTest.java
@@ -108,7 +108,7 @@ public class HistoryTest {
 
   @Test public void forwardIterator() {
     List<Object> paths = new ArrayList<>(Arrays.<Object>asList(ABLE, BAKER, CHARLIE));
-    History history = History.emptyBuilder().addAll(paths).build();
+    History history = History.emptyBuilder().pushAll(paths).build();
     for (Object o : history) {
       assertThat(o).isSameAs(paths.remove(paths.size() - 1));
     }
@@ -116,7 +116,7 @@ public class HistoryTest {
 
   @Test public void reverseIterator() {
     List<Object> paths = new ArrayList<>(Arrays.<Object>asList(ABLE, BAKER, CHARLIE));
-    History history = History.emptyBuilder().addAll(paths).build();
+    History history = History.emptyBuilder().pushAll(paths).build();
     Iterator<Object> i = history.reverseIterator();
     while (i.hasNext()) {
       assertThat(i.next()).isSameAs(paths.remove(0));
@@ -146,7 +146,7 @@ public class HistoryTest {
   }
 
   @Test public void historyIndexAccess() {
-    History history = History.emptyBuilder().addAll(asList(ABLE, BAKER, CHARLIE)).build();
+    History history = History.emptyBuilder().pushAll(asList(ABLE, BAKER, CHARLIE)).build();
     assertThat(history.peek(0)).isEqualTo(CHARLIE);
     assertThat(history.peek(1)).isEqualTo(BAKER);
     assertThat(history.peek(2)).isEqualTo(ABLE);
@@ -155,7 +155,7 @@ public class HistoryTest {
   @Test public void builderPreservesViewState() {
     List<TestState> states = asList(ABLE, BAKER, CHARLIE);
 
-    History history = History.emptyBuilder().addAll(states).build();
+    History history = History.emptyBuilder().pushAll(states).build();
 
     for (int i = states.size() - 1; i >= 0; i--) {
       View view = mock(View.class);

--- a/flow/src/test/java/flow/HistoryTest.java
+++ b/flow/src/test/java/flow/HistoryTest.java
@@ -16,27 +16,18 @@
 
 package flow;
 
-import android.os.Parcelable;
-import android.util.SparseArray;
-import android.view.View;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static java.util.Arrays.asList;
-import static junit.framework.Assert.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
 
 @RunWith(RobolectricTestRunner.class) // Necessary for functional SparseArray
 @Config(manifest = Config.NONE) //
@@ -150,37 +141,5 @@ public class HistoryTest {
     assertThat(history.peek(0)).isEqualTo(CHARLIE);
     assertThat(history.peek(1)).isEqualTo(BAKER);
     assertThat(history.peek(2)).isEqualTo(ABLE);
-  }
-
-  @Test public void builderPreservesViewState() {
-    List<TestState> states = asList(ABLE, BAKER, CHARLIE);
-
-    History history = History.emptyBuilder().pushAll(states).build();
-
-    for (int i = states.size() - 1; i >= 0; i--) {
-      View view = mock(View.class);
-      Parcelable viewState = mock(Parcelable.class);
-      mockSaveViewState(view, viewState);
-      history.peekSaveState(i).save(view);
-    }
-
-    History rebuiltHistory = history.buildUpon().clear().addAll(states).build();
-
-    for (int i = 0; i < history.size(); i++) {
-      assertEquals("Wrong view state at position " + i, history.peekSaveState(i),
-          rebuiltHistory.peekSaveState(i));
-    }
-  }
-
-  private void mockSaveViewState(View view, final Parcelable viewState) {
-    doAnswer(new Answer() {
-      @Override public Object answer(InvocationOnMock invocation) throws Throwable {
-        @SuppressWarnings("unchecked") //
-            SparseArray<Parcelable> outState =
-            (SparseArray<Parcelable>) invocation.getArguments()[0];
-        outState.put(0, viewState);
-        return null;
-      }
-    }).when(view).saveHierarchyState(Matchers.<SparseArray<Parcelable>>any());
   }
 }


### PR DESCRIPTION
State no longer lives in the History instance. This means building a
history is no longer unsafe. State is instead maintained by the
KeyManager, and History is just a list of keys.

States are created in the KeyManager on-demand to support traversals.

When the traversal queue is flushed we purge any stale/unused states
from the key manager.

Loading and saving state is no longer done via the History, but instead
handled directly by InternalLifecycleIntegration which pulls keys from
the current History and their States from the KeyManager; when loading,
it builds a History and pushes States into the KeyManager.

There are no longer any public APIs for loading and saving history, it's
all managed internally.

Fixes #148