### PR TITLE
Fixed `goBack()` during active traversal

### DIFF
--- a/flow/src/main/java/flow/Flow.java
+++ b/flow/src/main/java/flow/Flow.java
@@ -243,8 +243,8 @@ public final class Flow {
    * @return false if going back is not possible or a traversal is in progress.
    */
   @CheckResult public boolean goBack() {
-    boolean canGoBack = history.size() > 1 || (pendingTraversal != null
-        && pendingTraversal.state != TraversalState.FINISHED);
+    if(pendingTraversal != null && pendingTraversal.state != TraversalState.FINISHED) return true;
+    boolean canGoBack = history.size() > 1;
     if (!canGoBack) return false;
     History.Builder builder = history.buildUpon();
     builder.pop();


### PR DESCRIPTION
During an active traversal, `super.onBackPressed()` was called instead of Flow consuming the back press event, thus crashing during the creation of a History that was not to be created.

This fixes the crash, and blocks back press during an active traversal.