### PR TITLE
Crash when saving tree with duplicate View ids

### DIFF
--- a/flow/src/main/java/flow/State.java
+++ b/flow/src/main/java/flow/State.java
@@ -52,7 +52,7 @@ public class State {
   }
 
   public void save(@NonNull View view) {
-    SparseArray<Parcelable> state = new SparseArray<>();
+    SparseArray<Parcelable> state = new ViewTreeSparseArray();
     view.saveHierarchyState(state);
     viewState = state;
   }
@@ -114,6 +114,16 @@ public class State {
 
     @Nullable @Override public Bundle getBundle() {
       return null;
+    }
+  }
+
+  private final class ViewTreeSparseArray extends SparseArray<Parcelable> {
+    @Override public void put(int key, Parcelable value) {
+      int oldSize = size();
+      super.put(key, value);
+      if (oldSize == size()) {
+        throw new IllegalStateException("Duplicate View id in current tree being saved: " + key);
+      }
     }
   }
 }

--- a/flow/src/test/java/flow/StateTest.java
+++ b/flow/src/test/java/flow/StateTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package flow;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+import android.view.View;
+import android.widget.FrameLayout;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public final class StateTest {
+  @Test public void disallowDuplicateViewIds() {
+    Activity activity = Robolectric.setupActivity(Activity.class);
+    State state = State.fromBundle(new Bundle(), new KeyParceler() {
+      @NonNull @Override public Parcelable toParcelable(@NonNull Object key) {
+        return (Parcelable) key;
+      }
+
+      @NonNull @Override public Object toKey(@NonNull Parcelable parcelable) {
+        return parcelable;
+      }
+    });
+    int id = 1;
+    FrameLayout parent = new FrameLayout(activity);
+    parent.setId(id);
+    View child = new View(activity);
+    child.setId(id);
+    parent.addView(child);
+    try {
+      state.save(parent);
+      fail();
+    } catch (IllegalStateException expected) {
+      assertEquals("Duplicate View id in current tree being saved: 1", expected.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
I don't know if this is a worthwhile change for Flow, but I figured I'd post this simple trick here, as well. It prevents users from having subtle bugs from having duplicate View ids in the tree they are saving.