### PR TITLE
Adds Flow#updateHistory(HistoryUpdater)

### DIFF
--- a/flow/src/main/java/flow/Flow.java
+++ b/flow/src/main/java/flow/Flow.java
@@ -190,6 +190,19 @@ public final class Flow {
   }
 
   /**
+   * Accepts a {@link HistoryUpdater function} to be applied to the history, allowing a
+   * transition to be calculated.
+   */
+  public void updateHistory(@NonNull final HistoryUpdater updater) {
+    move(new PendingTraversal() {
+      @Override void doExecute() {
+        HistoryUpdater.Result result = updater.call(getHistory());
+        dispatch(preserveEquivalentPrefix(getHistory(), result.history), result.direction);
+      }
+    });
+  }
+
+  /**
    * Replaces the history with the given key and dispatches in the given direction.
    */
   public void replaceHistory(@NonNull final Object key, @NonNull final Direction direction) {
@@ -219,45 +232,7 @@ public final class Flow {
    * Objects' equality is always checked using {@link Object#equals(Object)}.
    */
   public void set(@NonNull final Object newTopKey) {
-    move(new PendingTraversal() {
-      @Override void doExecute() {
-        if (newTopKey.equals(history.top())) {
-          dispatch(history, Direction.REPLACE);
-          return;
-        }
-
-        History.Builder builder = history.buildUpon();
-        int count = 0;
-        // Search backward to see if we already have newTop on the stack
-        Object preservedInstance = null;
-        for (Iterator<Object> it = history.reverseIterator(); it.hasNext(); ) {
-          Object entry = it.next();
-
-          // If we find newTop on the stack, pop back to it.
-          if (entry.equals(newTopKey)) {
-            for (int i = 0; i < history.size() - count; i++) {
-              preservedInstance = builder.pop();
-            }
-            break;
-          } else {
-            count++;
-          }
-        }
-
-        History newHistory;
-        if (preservedInstance != null) {
-          // newTop was on the history. Put the preserved instance back on and dispatch.
-          builder.push(preservedInstance);
-          newHistory = builder.build();
-          dispatch(newHistory, Direction.BACKWARD);
-        } else {
-          // newTop was not on the history. Push it on and dispatch.
-          builder.push(newTopKey);
-          newHistory = builder.build();
-          dispatch(newHistory, Direction.FORWARD);
-        }
-      }
-    });
+    updateHistory(new HistoryUpdater.DoSet(newTopKey));
   }
 
   /**

--- a/flow/src/main/java/flow/HistoryUpdater.java
+++ b/flow/src/main/java/flow/HistoryUpdater.java
@@ -1,0 +1,69 @@
+package flow;
+
+import java.util.Iterator;
+
+/**
+ * A function that calculates the next state of a given {@link History}.
+ */
+public interface HistoryUpdater {
+
+  Result call(History history);
+
+  final class Result {
+    public final History history;
+    public final Direction direction;
+
+    public Result(History history, Direction direction) {
+      this.history = history;
+      this.direction = direction;
+    }
+
+    @Override public String toString() {
+      return String.format("%s: %s to %s", getClass().getName(), direction, history);
+    }
+  }
+
+  final class DoSet implements HistoryUpdater {
+    private final Object newTopKey;
+
+    public DoSet(Object newTopKey) {
+      this.newTopKey = newTopKey;
+    }
+
+    @Override public Result call(History history) {
+      if (newTopKey.equals(history.top())) {
+        return new Result(history, Direction.REPLACE);
+      }
+
+      History.Builder builder = history.buildUpon();
+      int count = 0;
+      // Search backward to see if we already have newTop on the stack
+      Object preservedInstance = null;
+      for (Iterator<Object> it = history.reverseIterator(); it.hasNext(); ) {
+        Object entry = it.next();
+
+        // If we find newTop on the stack, pop back to it.
+        if (entry.equals(newTopKey)) {
+          for (int i = 0; i < history.size() - count; i++) {
+            preservedInstance = builder.pop();
+          }
+          break;
+        } else {
+          count++;
+        }
+      }
+
+      History newHistory;
+      if (preservedInstance != null) {
+        // newTop was on the history. Put the preserved instance back on and dispatch.
+        builder.push(preservedInstance);
+        newHistory = builder.build();
+        return new Result(newHistory, Direction.BACKWARD);
+      }
+      // newTop was not on the history. Push it on and dispatch.
+      builder.push(newTopKey);
+      newHistory = builder.build();
+      return new Result(newHistory, Direction.FORWARD);
+    }
+  }
+}


### PR DESCRIPTION
In response to the discussion in #197. Allows app code to mutate the history
safely despite the raciness of asynchronous transitions.