### PR TITLE
Update exception message when flow is accessed too early

### DIFF
--- a/flow/src/main/java/flow/InternalLifecycleIntegration.java
+++ b/flow/src/main/java/flow/InternalLifecycleIntegration.java
@@ -47,7 +47,7 @@ public final class InternalLifecycleIntegration extends Fragment {
     Fragment fragmentByTag = find(activity);
     if (fragmentByTag == null) {
       throw new IllegalStateException("Flow services are not yet available. Do not make this call "
-          + "before receiving Activity#onPause().");
+          + "before receiving Activity#onResume().");
     }
     return (InternalLifecycleIntegration) fragmentByTag;
   }


### PR DESCRIPTION
Noticed there appears to be a typo in the exception message thrown when flow is accessed too early.