### PR TITLE
Deprecate History#iterator() and History#reverseIterator().

### DIFF
--- a/flow/src/main/java/flow/Flow.java
+++ b/flow/src/main/java/flow/Flow.java
@@ -51,8 +51,8 @@ public final class Flow {
    * Activity's {@link Activity#onResume()} method in the current Android task. In practice
    * this boils down to two rules:
    * <ol>
-   *   <li>In views, do not access Flow before {@link View#onAttachedToWindow()} is called.
-   *   <li>In activities, do not access flow before {@link Activity#onResume()} is called.
+   * <li>In views, do not access Flow before {@link View#onAttachedToWindow()} is called.
+   * <li>In activities, do not access flow before {@link Activity#onResume()} is called.
    * </ol>
    */
   @NonNull public static Flow get(@NonNull Context context) {
@@ -243,9 +243,7 @@ public final class Flow {
         int count = 0;
         // Search backward to see if we already have newTop on the stack
         Object preservedInstance = null;
-        for (Iterator<Object> it = history.reverseIterator(); it.hasNext(); ) {
-          Object entry = it.next();
-
+        for (Object entry : history.framesFromTop()) {
           // If we find newTop on the stack, pop back to it.
           if (entry.equals(newTopKey)) {
             for (int i = 0; i < history.size() - count; i++) {
@@ -321,8 +319,8 @@ public final class Flow {
   }
 
   private static History preserveEquivalentPrefix(History current, History proposed) {
-    Iterator<Object> oldIt = current.reverseIterator();
-    Iterator<Object> newIt = proposed.reverseIterator();
+    Iterator<Object> oldIt = current.framesFromTop().iterator();
+    Iterator<Object> newIt = proposed.framesFromTop().iterator();
 
     History.Builder preserving = current.buildUpon().clear();
 

--- a/flow/src/main/java/flow/InternalLifecycleIntegration.java
+++ b/flow/src/main/java/flow/InternalLifecycleIntegration.java
@@ -25,7 +25,6 @@ import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import java.util.ArrayList;
-import java.util.Iterator;
 
 import static flow.Preconditions.checkArgument;
 import static flow.Preconditions.checkNotNull;
@@ -117,9 +116,7 @@ public final class InternalLifecycleIntegration extends Fragment {
   static void addHistoryToIntent(Intent intent, History history, KeyParceler parceler) {
     Bundle bundle = new Bundle();
     ArrayList<Parcelable> parcelables = new ArrayList<>(history.size());
-    final Iterator<Object> keys = history.reverseIterator();
-    while (keys.hasNext()) {
-      Object key = keys.next();
+    for (Object key : history.framesFromTop()) {
       parcelables.add(State.empty(key).toBundle(parceler));
     }
     bundle.putParcelableArrayList(PERSISTENCE_KEY, parcelables);
@@ -207,9 +204,7 @@ public final class InternalLifecycleIntegration extends Fragment {
   private static void save(Bundle bundle, KeyParceler parceler, History history,
       KeyManager keyManager) {
     ArrayList<Parcelable> parcelables = new ArrayList<>(history.size());
-    final Iterator<Object> keys = history.reverseIterator();
-    while (keys.hasNext()) {
-      Object key = keys.next();
+    for (Object key : history.framesFromTop()) {
       if (!key.getClass().isAnnotationPresent(NotPersistent.class)) {
         parcelables.add(keyManager.getState(key).toBundle(parceler));
       }

--- a/flow/src/main/java/flow/NotPersistentHistoryFilter.java
+++ b/flow/src/main/java/flow/NotPersistentHistoryFilter.java
@@ -1,7 +1,6 @@
 package flow;
 
 import android.support.annotation.NonNull;
-import java.util.Iterator;
 
 /**
  * Default implementation of {@link HistoryFilter}, enforces the contract
@@ -11,9 +10,7 @@ class NotPersistentHistoryFilter implements HistoryFilter {
   @NonNull @Override public History scrubHistory(@NonNull History history) {
     History.Builder builder = History.emptyBuilder();
 
-    final Iterator<Object> keys = history.reverseIterator();
-    while (keys.hasNext()) {
-      Object key = keys.next();
+    for (Object key : history.framesFromTop()) {
       if (!key.getClass().isAnnotationPresent(NotPersistent.class)) {
         builder.push(key);
       }

--- a/flow/src/test/java/flow/FlowTest.java
+++ b/flow/src/test/java/flow/FlowTest.java
@@ -135,8 +135,8 @@ public class FlowTest {
       @Override
       public void dispatch(@NonNull Traversal traversal, @NonNull TraversalCallback onComplete) {
         assertThat(firstHistory).hasSameSizeAs(flow.getHistory());
-        Iterator<Object> original = firstHistory.iterator();
-        for (Object o : flow.getHistory()) {
+        Iterator<Object> original = firstHistory.framesFromBottom().iterator();
+        for (Object o : flow.getHistory().framesFromBottom()) {
           assertThat(o).isEqualTo(original.next());
         }
         onComplete.onTraversalCompleted();
@@ -460,9 +460,7 @@ public class FlowTest {
       @NonNull @Override public History scrubHistory(@NonNull History history) {
         History.Builder builder = History.emptyBuilder();
 
-        final Iterator<Object> keys = history.reverseIterator();
-        while (keys.hasNext()) {
-          Object key = keys.next();
+        for (Object key : history.framesFromTop()) {
           if (!key.equals(able)) {
             builder.push(key);
           }

--- a/flow/src/test/java/flow/HistoryTest.java
+++ b/flow/src/test/java/flow/HistoryTest.java
@@ -105,12 +105,28 @@ public class HistoryTest {
     }
   }
 
+  @Test public void framesFromBottom() {
+    List<Object> paths = new ArrayList<>(Arrays.<Object>asList(ABLE, BAKER, CHARLIE));
+    History history = History.emptyBuilder().pushAll(paths).build();
+    for (Object o : history.framesFromBottom()) {
+      assertThat(o).isSameAs(paths.remove(paths.size() - 1));
+    }
+  }
+
   @Test public void reverseIterator() {
     List<Object> paths = new ArrayList<>(Arrays.<Object>asList(ABLE, BAKER, CHARLIE));
     History history = History.emptyBuilder().pushAll(paths).build();
     Iterator<Object> i = history.reverseIterator();
     while (i.hasNext()) {
       assertThat(i.next()).isSameAs(paths.remove(0));
+    }
+  }
+
+  @Test public void framesFromTop() {
+    List<Object> paths = new ArrayList<>(Arrays.<Object>asList(ABLE, BAKER, CHARLIE));
+    History history = History.emptyBuilder().pushAll(paths).build();
+    for (Object o : history.framesFromTop()) {
+      assertThat(o).isSameAs(paths.remove(0));
     }
   }
 

--- a/flow/src/test/java/flow/ReentranceTest.java
+++ b/flow/src/test/java/flow/ReentranceTest.java
@@ -390,7 +390,7 @@ public class ReentranceTest {
 
   private void verifyHistory(History history, Object... keys) {
     List<Object> actualKeys = new ArrayList<>(history.size());
-    for (Object entry : history) {
+    for (Object entry : history.framesFromBottom()) {
       actualKeys.add(entry);
     }
     assertThat(actualKeys).containsExactly(keys);


### PR DESCRIPTION
The raw `iterator` methods on `History` do not make it clear you're iterating from the top or bottom of the stack. Introduced new methods `framesFromTop` and `framesFromBottom` to make it very clear. This also lets you use `for each` loops for both forward and backward iteration.

Fix for issue #261.