### PR TITLE
Swap the names of `framesFromTop` and `framesFromBottom` so they're correct.

### DIFF
--- a/flow/src/main/java/flow/Flow.java
+++ b/flow/src/main/java/flow/Flow.java
@@ -243,7 +243,7 @@ public final class Flow {
         int count = 0;
         // Search backward to see if we already have newTop on the stack
         Object preservedInstance = null;
-        for (Object entry : history.framesFromTop()) {
+        for (Object entry : history.framesFromBottom()) {
           // If we find newTop on the stack, pop back to it.
           if (entry.equals(newTopKey)) {
             for (int i = 0; i < history.size() - count; i++) {
@@ -319,8 +319,8 @@ public final class Flow {
   }
 
   private static History preserveEquivalentPrefix(History current, History proposed) {
-    Iterator<Object> oldIt = current.framesFromTop().iterator();
-    Iterator<Object> newIt = proposed.framesFromTop().iterator();
+    Iterator<Object> oldIt = current.framesFromBottom().iterator();
+    Iterator<Object> newIt = proposed.framesFromBottom().iterator();
 
     History.Builder preserving = current.buildUpon().clear();
 

--- a/flow/src/main/java/flow/History.java
+++ b/flow/src/main/java/flow/History.java
@@ -34,8 +34,8 @@ import static java.util.Collections.unmodifiableList;
  * Describes the history of a {@link Flow} at a specific point in time.
  *
  * <p><em>Note: use of this class as an {@link Iterable} is deprecated. Use {@link
- * #framesFromBottom()}
- * and {@link #framesFromTop()} instead.</em>
+ * #framesFromTop()}
+ * and {@link #framesFromBottom()} instead.</em>
  */
 public final class History implements Iterable<Object> {
 
@@ -50,11 +50,11 @@ public final class History implements Iterable<Object> {
     return emptyBuilder().push(key).build();
   }
 
-  private static <T> Iterator<T> iterateFromTop(List<Object> history) {
+  private static <T> Iterator<T> iterateFromBottom(List<Object> history) {
     return new ReadStateIterator<>(history.iterator());
   }
 
-  private static <T> Iterator<T> iterateFromBottom(List<Object> history) {
+  private static <T> Iterator<T> iterateFromTop(List<Object> history) {
     return new ReadStateIterator<>(new ReverseIterator<>(history));
   }
 
@@ -63,22 +63,22 @@ public final class History implements Iterable<Object> {
     this.history = history;
   }
 
-  @NonNull public <T> Iterable<T> framesFromTop() {
+  @NonNull public <T> Iterable<T> framesFromBottom() {
     return new HistoryIterable<>(history, true);
   }
 
-  @NonNull public <T> Iterable<T> framesFromBottom() {
+  @NonNull public <T> Iterable<T> framesFromTop() {
     return new HistoryIterable<>(history, false);
   }
 
-  /** @deprecated Use {@link #framesFromTop()} instead. */
+  /** @deprecated Use {@link #framesFromBottom()} instead. */
   @Deprecated @NonNull public <T> Iterator<T> reverseIterator() {
-    return iterateFromTop(history);
+    return iterateFromBottom(history);
   }
 
-  /** @deprecated Use {@link #framesFromBottom()} instead. */
+  /** @deprecated Use {@link #framesFromTop()} instead. */
   @Deprecated @NonNull @Override public Iterator<Object> iterator() {
-    return iterateFromBottom(history);
+    return iterateFromTop(history);
   }
 
   public int size() {
@@ -218,18 +218,18 @@ public final class History implements Iterable<Object> {
 
   private static class HistoryIterable<T> implements Iterable<T> {
     private final List<Object> history;
-    private final boolean fromTop;
+    private final boolean fromBottom;
 
-    HistoryIterable(List<Object> history, boolean fromTop) {
+    HistoryIterable(List<Object> history, boolean fromBottom) {
       this.history = history;
-      this.fromTop = fromTop;
+      this.fromBottom = fromBottom;
     }
 
     @NonNull @Override public Iterator<T> iterator() {
-      if (fromTop) {
-        return iterateFromTop(history);
-      } else {
+      if (fromBottom) {
         return iterateFromBottom(history);
+      } else {
+        return iterateFromTop(history);
       }
     }
   }

--- a/flow/src/main/java/flow/InternalLifecycleIntegration.java
+++ b/flow/src/main/java/flow/InternalLifecycleIntegration.java
@@ -116,7 +116,7 @@ public final class InternalLifecycleIntegration extends Fragment {
   static void addHistoryToIntent(Intent intent, History history, KeyParceler parceler) {
     Bundle bundle = new Bundle();
     ArrayList<Parcelable> parcelables = new ArrayList<>(history.size());
-    for (Object key : history.framesFromTop()) {
+    for (Object key : history.framesFromBottom()) {
       parcelables.add(State.empty(key).toBundle(parceler));
     }
     bundle.putParcelableArrayList(PERSISTENCE_KEY, parcelables);
@@ -204,7 +204,7 @@ public final class InternalLifecycleIntegration extends Fragment {
   private static void save(Bundle bundle, KeyParceler parceler, History history,
       KeyManager keyManager) {
     ArrayList<Parcelable> parcelables = new ArrayList<>(history.size());
-    for (Object key : history.framesFromTop()) {
+    for (Object key : history.framesFromBottom()) {
       if (!key.getClass().isAnnotationPresent(NotPersistent.class)) {
         parcelables.add(keyManager.getState(key).toBundle(parceler));
       }

--- a/flow/src/main/java/flow/NotPersistentHistoryFilter.java
+++ b/flow/src/main/java/flow/NotPersistentHistoryFilter.java
@@ -10,7 +10,7 @@ class NotPersistentHistoryFilter implements HistoryFilter {
   @NonNull @Override public History scrubHistory(@NonNull History history) {
     History.Builder builder = History.emptyBuilder();
 
-    for (Object key : history.framesFromTop()) {
+    for (Object key : history.framesFromBottom()) {
       if (!key.getClass().isAnnotationPresent(NotPersistent.class)) {
         builder.push(key);
       }

--- a/flow/src/test/java/flow/FlowTest.java
+++ b/flow/src/test/java/flow/FlowTest.java
@@ -135,8 +135,8 @@ public class FlowTest {
       @Override
       public void dispatch(@NonNull Traversal traversal, @NonNull TraversalCallback onComplete) {
         assertThat(firstHistory).hasSameSizeAs(flow.getHistory());
-        Iterator<Object> original = firstHistory.framesFromBottom().iterator();
-        for (Object o : flow.getHistory().framesFromBottom()) {
+        Iterator<Object> original = firstHistory.framesFromTop().iterator();
+        for (Object o : flow.getHistory().framesFromTop()) {
           assertThat(o).isEqualTo(original.next());
         }
         onComplete.onTraversalCompleted();
@@ -460,7 +460,7 @@ public class FlowTest {
       @NonNull @Override public History scrubHistory(@NonNull History history) {
         History.Builder builder = History.emptyBuilder();
 
-        for (Object key : history.framesFromTop()) {
+        for (Object key : history.framesFromBottom()) {
           if (!key.equals(able)) {
             builder.push(key);
           }

--- a/flow/src/test/java/flow/HistoryTest.java
+++ b/flow/src/test/java/flow/HistoryTest.java
@@ -108,9 +108,12 @@ public class HistoryTest {
   @Test public void framesFromBottom() {
     List<Object> paths = new ArrayList<>(Arrays.<Object>asList(ABLE, BAKER, CHARLIE));
     History history = History.emptyBuilder().pushAll(paths).build();
-    for (Object o : history.framesFromBottom()) {
-      assertThat(o).isSameAs(paths.remove(paths.size() - 1));
-    }
+    Iterator<Object> iterator = history.framesFromBottom().iterator();
+
+    assertThat(iterator.next()).isSameAs(ABLE);
+    assertThat(iterator.next()).isSameAs(BAKER);
+    assertThat(iterator.next()).isSameAs(CHARLIE);
+    assertThat(iterator.hasNext()).isFalse();
   }
 
   @Test public void reverseIterator() {
@@ -125,9 +128,12 @@ public class HistoryTest {
   @Test public void framesFromTop() {
     List<Object> paths = new ArrayList<>(Arrays.<Object>asList(ABLE, BAKER, CHARLIE));
     History history = History.emptyBuilder().pushAll(paths).build();
-    for (Object o : history.framesFromTop()) {
-      assertThat(o).isSameAs(paths.remove(0));
-    }
+    Iterator<Object> iterator = history.framesFromTop().iterator();
+
+    assertThat(iterator.next()).isSameAs(CHARLIE);
+    assertThat(iterator.next()).isSameAs(BAKER);
+    assertThat(iterator.next()).isSameAs(ABLE);
+    assertThat(iterator.hasNext()).isFalse();
   }
 
   @Test public void emptyBuilderPeekIsNullable() {

--- a/flow/src/test/java/flow/ReentranceTest.java
+++ b/flow/src/test/java/flow/ReentranceTest.java
@@ -390,7 +390,7 @@ public class ReentranceTest {
 
   private void verifyHistory(History history, Object... keys) {
     List<Object> actualKeys = new ArrayList<>(history.size());
-    for (Object entry : history.framesFromBottom()) {
+    for (Object entry : history.framesFromTop()) {
       actualKeys.add(entry);
     }
     assertThat(actualKeys).containsExactly(keys);


### PR DESCRIPTION
I added `framesFromTop` and `framesFromBottom` methods in 03d95786b2a960c352cbe3071f604066a5a2244c,
but the names of the methods were backwards.

Follow-up for fix for issue #261.