### PR TITLE
Unnecessary default value at KeyDispatcher.Builder

### DIFF
--- a/flow/src/main/java/flow/KeyDispatcher.java
+++ b/flow/src/main/java/flow/KeyDispatcher.java
@@ -43,8 +43,6 @@ public final class KeyDispatcher implements Dispatcher {
     }
 
     public Dispatcher build() {
-      final KeyChanger keyChanger =
-          this.keyChanger == null ? new DefaultKeyChanger(activity) : this.keyChanger;
       return new KeyDispatcher(activity, keyChanger);
     }
   }


### PR DESCRIPTION
The builder constructor checks that keyChanger is never null, so we don't need a default value.